### PR TITLE
override get_config for transformer block and change dropout layer name

### DIFF
--- a/vit_keras/layers.py
+++ b/vit_keras/layers.py
@@ -132,13 +132,18 @@ class TransformerBlock(tf.keras.layers.Layer):
         self.layernorm2 = tf.keras.layers.LayerNormalization(
             epsilon=1e-6, name="LayerNorm_2"
         )
-        self.dropout = tf.keras.layers.Dropout(self.dropout)
+        self.dropout_layer = tf.keras.layers.Dropout(self.dropout)
 
     def call(self, inputs, training):
         x = self.layernorm1(inputs)
         x, weights = self.att(x)
-        x = self.dropout(x, training=training)
+        x = self.dropout_layer(x, training=training)
         x = x + inputs
         y = self.layernorm2(x)
         y = self.mlpblock(y)
         return x + y, weights
+
+    def get_config(self):
+        return {"num_heads": self.num_heads,
+                "mlp_dim": self.mlp_dim,
+                "dropout": self.dropout}


### PR DESCRIPTION
Hi,

This change overrides the get_config method of the TransformerBlock custom layer so the ViT models can be loaded with tensorflow.keras.models.load_model. Also changed the name of the dropout layer in this custom layer so it doesn't override the dropout rate anymore

I hope this is helpful!

Proinn