### PR TITLE
Update visualize.py: Flexible Image Size

### DIFF
--- a/vit_keras/visualize.py
+++ b/vit_keras/visualize.py
@@ -12,11 +12,11 @@ def attention_map(model, image):
         model: A ViT model
         image: An image for which we will compute the attention map.
     """
-    size = model.input_shape[1]
+    img_height, img_width = model.input_shape[0], model.input_shape[1]
     grid_size = int(np.sqrt(model.layers[5].output_shape[0][-2] - 1))
 
     # Prepare the input
-    X = vit.preprocess_inputs(cv2.resize(image, (size, size)))[np.newaxis, :]  # type: ignore
+    X = vit.preprocess_inputs(cv2.resize(image, (img_height, img_width)))[np.newaxis, :]  # type: ignore
 
     # Get the attention weights from each transformer.
     outputs = [


### PR DESCRIPTION
Added flexible input image size for attention map visualization.

I was using this excellent repo. However, when I wanted to visualize the attention map, I noticed that visualize.py accepts just square input (but mine was rectangle). That is why I adjusted the attention map function: as it will get the dimensions of the height and width of the model input shape, then it will resize a given image to that input shape (not to a square).