### PR TITLE
Drop Tensorflow Addons support (TF>2.14)

### DIFF
--- a/vit_keras/layers.py
+++ b/vit_keras/layers.py
@@ -143,7 +143,7 @@ class TransformerBlock(tf.keras.layers.Layer):
                 ),
                 tf.keras.layers.Lambda(
                     lambda x: tf.keras.activations.gelu(x, approximate=False)
-                )
+                ),
                 tf.keras.layers.Dropout(self.dropout),
                 tf.keras.layers.Dense(input_shape[-1], name=f"{self.name}/Dense_1"),
                 tf.keras.layers.Dropout(self.dropout),

--- a/vit_keras/layers.py
+++ b/vit_keras/layers.py
@@ -1,7 +1,5 @@
 # pylint: disable=arguments-differ,missing-function-docstring,missing-class-docstring,unexpected-keyword-arg,no-value-for-parameter
 import tensorflow as tf
-import tensorflow_addons as tfa
-
 
 @tf.keras.utils.register_keras_serializable()
 class ClassToken(tf.keras.layers.Layer):
@@ -146,10 +144,6 @@ class TransformerBlock(tf.keras.layers.Layer):
                 tf.keras.layers.Lambda(
                     lambda x: tf.keras.activations.gelu(x, approximate=False)
                 )
-                if hasattr(tf.keras.activations, "gelu")
-                else tf.keras.layers.Lambda(
-                    lambda x: tfa.activations.gelu(x, approximate=False)
-                ),
                 tf.keras.layers.Dropout(self.dropout),
                 tf.keras.layers.Dense(input_shape[-1], name=f"{self.name}/Dense_1"),
                 tf.keras.layers.Dropout(self.dropout),


### PR DESCRIPTION
Hi @faustomorales,
first of all, thanks for this awesome package and your work! 

Bug: Tensorflow Addons (TFA) dropped maintenance with Keras update 2->3.

Solution: All necessary functions of TFA are available in Keras 3.

Affected positions: Activation layer GELU.
Pull Request: Remove TFA import in layers.py and use Keras 3 GELU.

Side effect:
Tensorflow versions utilizing < Keras 3 (all versions bellow 2.15?) are not supported anymore.
Positive effect:
All up-to-date Tensorflow versions >=2.15 are functional now, again.

Fixes issues #44 and #43

Cheers,
Dominik